### PR TITLE
potd/timelapse/templates/camera.html

### DIFF
--- a/potd/timelapse/templates/camera.html
+++ b/potd/timelapse/templates/camera.html
@@ -9,11 +9,8 @@
 	background-position: 50% 0;
 	background-repeat: no-repeat;
 	background-size: cover;
-	-webkit-background-size: cover;
-	-moz-background-size: cover;
-	-o-background-size: cover;
-	width:100%;
-        height: 800px;
+	width: 100%;
+	height: 800px;
 	position: relative;
 }
 .parallaxphoto span {
@@ -27,6 +24,17 @@
 	position: absolute;
 	text-shadow: 0 2px 0 black, 0 0 10px black;
 	width: 100%;
+}
+
+@media only screen and (max-device-width: 1024px) {
+	.parallaxphoto {
+		background-attachment: scroll;
+		-webkit-background-size: cover;
+		-moz-background-size: cover;
+		-o-background-size: cover;
+		background-size: cover;
+		width:100%;
+	}
 }
 
 {% for photo in todays_images %}


### PR DESCRIPTION
Fixes background images on mobile so it doesn't look like wart-covered ass.
